### PR TITLE
Adapt pgbackrest installation to debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If using [Xait's postgres role](https://gitlab.xait.no/collab/xait_software_post
 
 ## Role Variables
 
+- `pgbackrest_version` package version to install.
 - `pgbackrest_restore_standby` set to true to restore from a standby from the stanza with `recovery-option` set.
 - `pgbackrest_local_postgresql` set to `false` if pgbackrest host doesn't have PG installed locally.
 - `pgbackrest_services_install` set to `false` to skip installing backup services/timers.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 
 postgresql_version: 14
 
+pgbackrest_version: 2.49-*
+
 pgbackrest_owner: postgres
 pgbackrest_group: postgres
 pgbackrest_local_postgresql: "{{ 'pg' in group_names }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,9 +1,4 @@
 ---
-
-dependencies:
-  - name: pg_repo
-    src: https://github.com/cosandr/ansible-role-pg_repo.git
-
 galaxy_info:
   role_name: pgbackrest
   namespace: xait

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Install pgbackrest
   package:
-    name: pgbackrest
+    name: "pgbackrest={{ pgbackrest_version }}"
     state: present
   tags: ["install"]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   when: "'spool-path' in pgbackrest_global_config"
 
 - name: Install pgbackrest
-  yum:
+  package:
     name: pgbackrest
     state: present
   tags: ["install"]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,3 +63,8 @@
   loop_control:
     loop_var: repo
   when: pgbackrest_services_install | bool
+
+- name: Install check-pgbackrest
+  package:
+    name: "check-pgbackrest"
+    state: latest


### PR DESCRIPTION
## Description
Adapt pgbackrest installation to debian and by the way pin the package version.

Note: we add only the few changes needed for now in this PR, and not the other changes we should make to the forked role to make it compliant with our ansible best practices.

By the way, even if we don't use Nagios, we install the `check-pgbackrest` plugin that provides interesting check features that we can use to monitor backup and wal archiving.

## Test

Validate that an ansible run is executed without error, that the pinned pgbackrest version is installed and correctly configured and working...
```
postgres@xxxxxxx:~$ pgbackrest version
pgBackRest 2.49

postgres@xxxxxxx:~$ pgbackrest check
[...]
2024-01-12 16:35:27.976 P00   INFO: check stanza 'main'
2024-01-12 16:35:28.639 P00   INFO: check repo1 configuration (primary)
2024-01-12 16:35:29.142 P00   INFO: check repo1 archive for WAL (primary)
2024-01-12 16:35:29.925 P00   INFO: WAL segment 000000010000000000000006 successfully archived to '/pgbackrest/[...]/archive/main/15-1/0000000100000000/000000010000000000000006-e6ee4b1006f7bfb874d304f7fabbc081ab7922ca.gz' on repo1
2024-01-12 16:35:30.435 P00   INFO: check command end: completed successfully (2460ms)
```
... and that `check-pgbackrest` is installed
```
postgres@xxxxxxx:~$ check_pgbackrest --version
check_pgbackrest version 2.3, Perl 5.32.1
```