### PR TITLE
Bump to 2.50

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 postgresql_version: 14
 
-pgbackrest_version: 2.49-*
+pgbackrest_version: 2.50-*
 
 pgbackrest_owner: postgres
 pgbackrest_group: postgres

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,8 +63,3 @@
   loop_control:
     loop_var: repo
   when: pgbackrest_services_install | bool
-
-- name: Install check-pgbackrest
-  package:
-    name: "check-pgbackrest"
-    state: latest


### PR DESCRIPTION
## Description

- Bump default version to [2.50](https://pgbackrest.org/release.html#2.50)
- Revert check-pgbackrest install (moved to our main repo)

## Test
Validate that an ansible run is executed without error, that the pinned pgbackrest version is installed and correctly configured and working...
```
postgres@xxxxxxx:~$ pgbackrest version
pgBackRest 2.50

postgres@xxxxxxx:~$ pgbackrest check
[...]
2024-01-31 18:28:42.459 P00   INFO: check stanza 'main'
2024-01-31 18:28:42.673 P00   INFO: check repo1 configuration (primary)
2024-01-31 18:28:43.194 P00   INFO: check repo1 archive for WAL (primary)
2024-01-31 18:28:44.376 P00   INFO: WAL segment 00000001000000010000002C successfully archived to '/pgbackrest/[...]/archive/main/15-1/0000000100000001/00000001000000010000002C-f6e73b0c50e14af37bcc143cce7e633c86ee7aa6.gz' on repo1
2024-01-31 18:28:44.414 P00   INFO: check command end: completed successfully (1960ms)
```