### PR TITLE
Bump default version to 2.52

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 postgresql_version: 14
 
-pgbackrest_version: 2.50-*
+pgbackrest_version: 2.52-*
 
 pgbackrest_owner: postgres
 pgbackrest_group: postgres


### PR DESCRIPTION
# Description

Bump to 2.52 : version 2.50 is no longer available in the PostgreSQL repo.